### PR TITLE
Add docker-compose for development

### DIFF
--- a/DockerfileDev
+++ b/DockerfileDev
@@ -1,0 +1,25 @@
+FROM ubuntu:18.04
+
+RUN apt-get update --yes && apt-get upgrade --yes
+RUN apt-get install --yes \
+	apt-utils \
+	build-essential \
+	debhelper \
+	devscripts \
+	make \
+	python3 \
+	python3-dev \
+	python3-virtualenv \
+	sudo \
+	virtualenv \
+	nodejs \
+	npm
+
+COPY . /app
+WORKDIR /app
+
+RUN make devel
+
+EXPOSE 8001
+
+CMD ./bin/manage runserver --insecure 0.0.0.0:8001

--- a/README.rst
+++ b/README.rst
@@ -162,6 +162,20 @@ After cloning the repository, you can easily deploy the app for development:
 
 Open ``http://localhost:8001/`` and you should be able to log-in.
 
+For development - Docker
+~~~~~~~~~~~~~~~
+
+Works out of the box, no prerequisites besides docker needed
+
+#. Clone the repo and go to the vpnathome directory.
+#. Run ``docker-compose up``. Docker will `install and start a development server`_ for you.
+#. Now you can go to ``http://localhost:8001/`` and you will be able to login.
+#. Make some changes. The container will automatically pick them up `via a volume`_.
+#. After you saved the changes, you can refresh ``http://localhost:8001/`` and will see them immediately.
+
+.. _`install and start a development server`: DockerfileDev
+.. _`via a volume`: docker-compose.yml#L11
+
 For production - Docker
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+  app_dev:
+    build:
+      context: ./
+      dockerfile: DockerfileDev
+    ports:
+      - "8001:8001"
+    volumes:
+      - ./:/app
+      - env:/app/env
+      - data:/app/data
+      - node_modules:/app/frontend/node_modules
+
+volumes:
+  env:
+  data:
+  node_modules:


### PR DESCRIPTION
Hi @ezaquarii

first of all thank you for the great work on this project! It really helped me out making my RBPi accessible from the internet! :)
 
Right now, in order to contribute to vpn-at-home, a developer needs to install the [prerequisites](https://github.com/ezaquarii/vpn-at-home#prerequisites) and make sure things are in ${PATH}. 

While for seasoned developers, this might not be a problem, but
- It is an barrier for some, especially people who are new to a stack. 
- Not everyone is willed to pollute his machine with dependencies just to contribute a quick fix. 

Take my exampe: I am mainly a front-end dev by training, and I initially I came to this repo to work on a small [front-end thing](https://github.com/ezaquarii/vpn-at-home/issues/26). But without docker this means I have to work with django, virtualenv, ansible and so on. This makes it hard for me. 

With this PR I could just run one command and would be ready to work on what I came to work on. Since it would make the dev environment reproducible, things like [this](https://github.com/ezaquarii/vpn-at-home/issues/26#issuecomment-450072512) could be made easier for the future. I have also the confidence, that if I break something, I can just throw away the container and rebuild it! 

IMHO it makes the project more accessible for contributors. It should also be noted, that [IDEs do work with Docker](https://blog.jetbrains.com/pycharm/2015/12/using-docker-in-pycharm/). And it's also totally optional!

Let me know what you think, what requirements you have for this, and what you would like to change! 



