### PR TITLE
[frontend] Add autoscroll to deployment progress dialog

### DIFF
--- a/frontend/src/components/DeploymentDialog.vue
+++ b/frontend/src/components/DeploymentDialog.vue
@@ -62,17 +62,25 @@ export default class DeploymentDialog extends Vue {
     }
 
     onStart () {
-        this.output.push('Deployment started', "Ignore first '[ERROR]:' line - this is harmless Ansible bug. :o)");
+        this.pushAutoScroll('Deployment started', "Ignore first '[ERROR]:' line - this is harmless Ansible bug. :o)");
     }
 
     onFinish () {
-        this.output.push('Deployment finished.');
+        this.pushAutoScroll('Deployment finished.');
         this.isRunning = false;
         this.finished = true;
     }
 
     onOutput (output) {
-        this.output.push(...output);
+        this.pushAutoScroll(...output);
+    }
+
+    pushAutoScroll (output) {
+        this.output.push(output);
+        var con = document.getElementsByClassName('content scrolling')[0];
+        if (con.scrollTop >= con.scrollHeight - con.clientHeight) {
+            this.$nextTick(function () { con.scrollTop = con.scrollHeight - con.clientHeight; });
+        }
     }
 
 }


### PR DESCRIPTION
Attempt to close #26 

A lot more difficult than I first thought it would be. The `$nextTick call` is required because updates from calling `this.output.push()` happen asynchronously(?) and the scrolling would take place before the last item was added to the dialog. This way, the scroll is done right after each item is added.

Let me know if I did this correctly, as this is still all very new to me. Thanks.